### PR TITLE
Python3 compatibility Fix

### DIFF
--- a/pymailinator/tests/test_wrapper.py
+++ b/pymailinator/tests/test_wrapper.py
@@ -48,14 +48,14 @@ def get_message(url):
 # noinspection PyArgumentList
 class TestWrapper(unittest.TestCase):
     def test_empty_mailbox(self):
-        wrapper.urllib.urlopen = get_empty_mailbox
+        wrapper.urlopen = get_empty_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertEqual(inbox.count(), 0)
         self.assertEquals(inbox.messages, [])
 
     def test_bad_token(self):
-        wrapper.urllib.urlopen = get_bad_api_token
+        wrapper.urlopen = get_bad_api_token
         inbox = wrapper.Inbox('123')
         with self.assertRaises(wrapper.InvalidToken):
             inbox.get()
@@ -65,64 +65,64 @@ class TestWrapper(unittest.TestCase):
             wrapper.Inbox()
 
     def test_invalid_token(self):
-        wrapper.urllib.urlopen = get_missing_token
+        wrapper.urlopen = get_missing_token
         inbox = wrapper.Inbox(False)
         with self.assertRaises(wrapper.MissingToken):
             inbox.get()
 
     def test_successful_mailbox(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertGreater(inbox.count(), 0)
 
     def test_successful_message(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
-        wrapper.urllib.urlopen = get_message
+        wrapper.urlopen = get_message
         message = inbox.messages[0]
         message.get_message()
         self.assertNotEquals(message.body, '')
 
     def test_missing_message(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
-        wrapper.urllib.urlopen = get_missing_message
+        wrapper.urlopen = get_missing_message
         with self.assertRaises(wrapper.MessageNotFound):
             inbox.messages[0].get_message()
 
     def test_view_subjects(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertEquals(type(inbox.view_subjects()), list)
         self.assertGreater(len(inbox.view_subjects()), 0)
 
     def test_view_message_ids(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertEquals(type(inbox.view_message_ids()), list)
         self.assertGreater(len(inbox.view_message_ids()), 0)
 
     def test_get_message_by_subject(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         message = inbox.get_message_by_subject('Want to cheat? ')
         self.assertEquals(message.subject, 'Want to cheat? ')
 
     def test_get_message_by_id(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         message = inbox.get_message_by_id('1418740612-3134545-m8r-rmtci4')
         self.assertEquals(message.id, '1418740612-3134545-m8r-rmtci4')
 
     def test_filter_inbox(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         filtered_me = inbox.filter('to', 'me')
@@ -131,7 +131,7 @@ class TestWrapper(unittest.TestCase):
         self.assertEquals(len(filtered), 2)
 
     def test_other_mailbox(self):
-        wrapper.urllib.urlopen = get_mailbox
+        wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get('other')
         self.assertGreater(inbox.count(), 0)

--- a/pymailinator/tests/test_wrapper.py
+++ b/pymailinator/tests/test_wrapper.py
@@ -52,7 +52,7 @@ class TestWrapper(unittest.TestCase):
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertEqual(inbox.count(), 0)
-        self.assertEquals(inbox.messages, [])
+        self.assertEqual(inbox.messages, [])
 
     def test_bad_token(self):
         wrapper.urlopen = get_bad_api_token
@@ -83,7 +83,7 @@ class TestWrapper(unittest.TestCase):
         wrapper.urlopen = get_message
         message = inbox.messages[0]
         message.get_message()
-        self.assertNotEquals(message.body, '')
+        self.assertNotEqual(message.body, '')
 
     def test_missing_message(self):
         wrapper.urlopen = get_mailbox
@@ -97,14 +97,14 @@ class TestWrapper(unittest.TestCase):
         wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
-        self.assertEquals(type(inbox.view_subjects()), list)
+        self.assertEqual(type(inbox.view_subjects()), list)
         self.assertGreater(len(inbox.view_subjects()), 0)
 
     def test_view_message_ids(self):
         wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
-        self.assertEquals(type(inbox.view_message_ids()), list)
+        self.assertEqual(type(inbox.view_message_ids()), list)
         self.assertGreater(len(inbox.view_message_ids()), 0)
 
     def test_get_message_by_subject(self):
@@ -112,23 +112,23 @@ class TestWrapper(unittest.TestCase):
         inbox = wrapper.Inbox('123')
         inbox.get()
         message = inbox.get_message_by_subject('Want to cheat? ')
-        self.assertEquals(message.subject, 'Want to cheat? ')
+        self.assertEqual(message.subject, 'Want to cheat? ')
 
     def test_get_message_by_id(self):
         wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         message = inbox.get_message_by_id('1418740612-3134545-m8r-rmtci4')
-        self.assertEquals(message.id, '1418740612-3134545-m8r-rmtci4')
+        self.assertEqual(message.id, '1418740612-3134545-m8r-rmtci4')
 
     def test_filter_inbox(self):
         wrapper.urlopen = get_mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         filtered_me = inbox.filter('to', 'me')
-        self.assertEquals(len(filtered_me), 0)
+        self.assertEqual(len(filtered_me), 0)
         filtered = inbox.filter('to', 'm8r-rmtci4@mailinator.com')
-        self.assertEquals(len(filtered), 2)
+        self.assertEqual(len(filtered), 2)
 
     def test_other_mailbox(self):
         wrapper.urlopen = get_mailbox

--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -1,5 +1,10 @@
 import json
-import urllib
+
+try:
+    from urllib.request import urlopen
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlopen, urlencode
 
 
 class InvalidToken(Exception):
@@ -35,8 +40,8 @@ class Message(object):
 
     def get_message(self):
         query_string = {'token': self.token, 'msgid': self.id}
-        url = self._baseURL + "?" + urllib.urlencode(query_string)
-        request = urllib.urlopen(url)
+        url = self._baseURL + "?" + urlencode(query_string)
+        request = urlopen(url)
         if request.getcode() == 404:
             raise MessageNotFound
         response = request.read()
@@ -76,8 +81,8 @@ class Inbox(object):
             query_string.update({'to': mailbox})
         if private_domain:
             query_string.update({'private_domain': json.dumps(private_domain)})
-        url = self._baseURL + '?' + urllib.urlencode(query_string)
-        request = urllib.urlopen(url)
+        url = self._baseURL + '?' + urlencode(query_string)
+        request = urlopen(url)
         if request.getcode() == 400:
             raise InvalidToken
         response = request.read()
@@ -127,4 +132,4 @@ class Inbox(object):
 
 
 def clean_response(response):
-    return response.replace('\r\n', '').decode('utf-8', 'ignore')
+    return response.decode('utf-8', 'ignore')

--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 try:
     from urllib.request import urlopen
@@ -132,4 +133,7 @@ class Inbox(object):
 
 
 def clean_response(response):
-    return response.decode('utf-8', 'ignore')
+    if six.PY2:
+        return response.decode('utf-8', 'ignore')
+    else:
+        return response


### PR DESCRIPTION
I've changed how imports work so that we can use py-mailinator both in python3 and python2. I had to modify only slightly and in one point at clean_response I had to use six because in python3 response was already decoded. Tests are passing in both py3/py2 virtualenvs and I checked manually. Also assertNotEquals and assertEqual are deprecated in Py3, I've changed it to assertEqual and assertNotEqual. This will be compatible in py2.7 and above.