### PR TITLE
encoding fix, six not needed

### DIFF
--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -1,5 +1,4 @@
 import json
-import six
 
 try:
     from urllib.request import urlopen
@@ -133,7 +132,8 @@ class Inbox(object):
 
 
 def clean_response(response):
-    if six.PY2:
+    if not isinstance(response, str):
         return response.decode('utf-8', 'ignore')
     else:
         return response
+


### PR DESCRIPTION
While it was working in production i noticed an error when bytes type arrives for data. My initial idea was to use six but it is not necessary. This is better. It keeps successful  test execution and decodes only if bytes are sent. Please merge this because this is a fix to the bug i noticed in production. Bump the version on pypi


TypeError: the JSON object must be str, not 'bytes'

