### PR TITLE
Fix too many requests

### DIFF
--- a/pymailinator/tests/test_wrapper.py
+++ b/pymailinator/tests/test_wrapper.py
@@ -45,6 +45,18 @@ def get_message(url):
     return MockResponse(status=200, filename=filename, url=url)
 
 
+class MockServerTooManyRequests(object):
+    def __init__(self, count, response):
+        self.count = count
+        self.response = response
+
+    def get(self, url):
+        if self.count > 0:
+            self.count -= 1
+            return MockResponse(status=429, content='', url=url)
+        return self.response(url)
+
+
 # noinspection PyArgumentList
 class TestWrapper(unittest.TestCase):
     def test_empty_mailbox(self):
@@ -70,59 +82,59 @@ class TestWrapper(unittest.TestCase):
         with self.assertRaises(wrapper.MissingToken):
             inbox.get()
 
-    def test_successful_mailbox(self):
-        wrapper.urlopen = get_mailbox
+    def test_successful_mailbox(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertGreater(inbox.count(), 0)
 
-    def test_successful_message(self):
-        wrapper.urlopen = get_mailbox
+    def test_successful_message(self, mailbox=get_mailbox, message=get_message):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
-        wrapper.urlopen = get_message
+        wrapper.urlopen = message
         message = inbox.messages[0]
         message.get_message()
         self.assertNotEqual(message.body, '')
 
-    def test_missing_message(self):
-        wrapper.urlopen = get_mailbox
+    def test_missing_message(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         wrapper.urlopen = get_missing_message
         with self.assertRaises(wrapper.MessageNotFound):
             inbox.messages[0].get_message()
 
-    def test_view_subjects(self):
-        wrapper.urlopen = get_mailbox
+    def test_view_subjects(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertEqual(type(inbox.view_subjects()), list)
         self.assertGreater(len(inbox.view_subjects()), 0)
 
-    def test_view_message_ids(self):
-        wrapper.urlopen = get_mailbox
+    def test_view_message_ids(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         self.assertEqual(type(inbox.view_message_ids()), list)
         self.assertGreater(len(inbox.view_message_ids()), 0)
 
-    def test_get_message_by_subject(self):
-        wrapper.urlopen = get_mailbox
+    def test_get_message_by_subject(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         message = inbox.get_message_by_subject('Want to cheat? ')
         self.assertEqual(message.subject, 'Want to cheat? ')
 
-    def test_get_message_by_id(self):
-        wrapper.urlopen = get_mailbox
+    def test_get_message_by_id(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         message = inbox.get_message_by_id('1418740612-3134545-m8r-rmtci4')
         self.assertEqual(message.id, '1418740612-3134545-m8r-rmtci4')
 
-    def test_filter_inbox(self):
-        wrapper.urlopen = get_mailbox
+    def test_filter_inbox(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get()
         filtered_me = inbox.filter('to', 'me')
@@ -130,11 +142,33 @@ class TestWrapper(unittest.TestCase):
         filtered = inbox.filter('to', 'm8r-rmtci4@mailinator.com')
         self.assertEqual(len(filtered), 2)
 
-    def test_other_mailbox(self):
-        wrapper.urlopen = get_mailbox
+    def test_other_mailbox(self, mailbox=get_mailbox):
+        wrapper.urlopen = mailbox
         inbox = wrapper.Inbox('123')
         inbox.get('other')
         self.assertGreater(inbox.count(), 0)
+
+    def tests_too_many_request(self):
+        wrapper.TIME_SLEEP_TOO_MANY_REQUESTS = .1
+        for test_func in (
+            'test_successful_mailbox',
+            'test_successful_message',
+            'test_missing_message',
+            'test_view_subjects',
+            'test_view_message_ids',
+            'test_get_message_by_subject',
+            'test_get_message_by_id',
+            'test_filter_inbox',
+            'test_other_mailbox',
+        ):
+            mock_server = MockServerTooManyRequests(2, get_mailbox)
+            getattr(self, test_func)(mailbox=mock_server.get)
+
+        for test_func in (
+            'test_successful_message',
+        ):
+            mock_server = MockServerTooManyRequests(2, get_message)
+            getattr(self, test_func)(message=mock_server.get)
 
 
 if __name__ == '__main__':

--- a/pymailinator/tests/test_wrapper.py
+++ b/pymailinator/tests/test_wrapper.py
@@ -170,6 +170,11 @@ class TestWrapper(unittest.TestCase):
             mock_server = MockServerTooManyRequests(2, get_message)
             getattr(self, test_func)(message=mock_server.get)
 
+        with self.assertRaises(wrapper.TooManyRequests):
+            wrapper.NUMBER_ATTEMPTS_TOO_MANY_REQUESTS = 3
+            mock_server = MockServerTooManyRequests(4, get_mailbox)
+            self.test_successful_mailbox(mailbox=mock_server.get)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -8,7 +8,7 @@ except ImportError:
     from urllib import urlopen, urlencode
 
 
-TIME_SLEEP_TOO_MANY_REQUESTS = 1.2
+TIME_SLEEP_TOO_MANY_REQUESTS = .7
 
 
 class InvalidToken(Exception):

--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -9,6 +9,11 @@ except ImportError:
 
 
 TIME_SLEEP_TOO_MANY_REQUESTS = .7
+NUMBER_ATTEMPTS_TOO_MANY_REQUESTS = 12
+
+
+class TooManyRequests(Exception):
+    pass
 
 
 class InvalidToken(Exception):
@@ -150,9 +155,11 @@ def clean_response(response):
 
 
 def get_request(url, sleep_time=.7):
-    while True:
+    for i in range(NUMBER_ATTEMPTS_TOO_MANY_REQUESTS):
         request = urlopen(url)
         if request.getcode() != 429:
             break
         sleep(TIME_SLEEP_TOO_MANY_REQUESTS)
+    else:
+        raise TooManyRequests
     return request

--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -1,10 +1,14 @@
 import json
+from time import sleep
 
 try:
     from urllib.request import urlopen
     from urllib.parse import urlencode
 except ImportError:
     from urllib import urlopen, urlencode
+
+
+TIME_SLEEP_TOO_MANY_REQUESTS = 1.2
 
 
 class InvalidToken(Exception):
@@ -45,7 +49,7 @@ class Message(object):
     def get_message(self):
         query_string = {'token': self.token, 'msgid': self.id}
         url = self._baseURL + "?" + urlencode(query_string)
-        request = urlopen(url)
+        request = get_request(url)
         if request.getcode() == 404:
             raise MessageNotFound
         response = request.read()
@@ -89,7 +93,7 @@ class Inbox(object):
         if private_domain:
             query_string.update({'private_domain': json.dumps(private_domain)})
         url = self._baseURL + '?' + urlencode(query_string)
-        request = urlopen(url)
+        request = get_request(url)
         if request.getcode() == 400:
             raise InvalidToken
         response = request.read()
@@ -144,3 +148,11 @@ def clean_response(response):
     else:
         return response
 
+
+def get_request(url, sleep_time=.7):
+    while True:
+        request = urlopen(url)
+        if request.getcode() != 429:
+            break
+        sleep(TIME_SLEEP_TOO_MANY_REQUESTS)
+    return request


### PR DESCRIPTION
This code:
```python
...
from pymailinator.wrapper import Inbox
...
inbox = Inbox(MAILINATOR_API_KEY)
inbox.get(username)
messages = inbox.messages
if not messages:
    return
message = messages[0]
message.get_message()
print message.body
```

throws an exception:
```
  File "main.py", in main
    message.get_message()
  File "venv/local/lib/python2.7/site-packages/pymailinator/wrapper.py", line 52, in get_message
    data = json.loads(clean_response(response), strict=False)
  File "/usr/lib/python2.7/json/__init__.py", line 351, in loads
    return cls(encoding=encoding, **kw).decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

because response is empty string - urlopen returned 429 http code (too many requests). `sleep(n)` before `message.get_message()` helps.

This fix after receiving 429 waits some time and sends request. Tried to add it in tests.