### PR TITLE
Support the new `origfrom` message attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Attributes:
 * `subject` : message subject line
 * `time` : message delivery time
 * `seconds_ago` : number of seconds between time of delivery and time of request
-* `fromshort` : short from field
-* `fromfull`: full from field
+* `origfrom` : Original from field
 * `ip` : ip address the email was sent from
 * `been_read` : boolean if messsage has been opened
 * `headers` : only available after `get_message()`, shows the message headers

--- a/pymailinator/tests/test_wrapper.py
+++ b/pymailinator/tests/test_wrapper.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+from collections import defaultdict
+
 from pymailinator import wrapper
 
 
@@ -174,6 +176,15 @@ class TestWrapper(unittest.TestCase):
             wrapper.NUMBER_ATTEMPTS_TOO_MANY_REQUESTS = 3
             mock_server = MockServerTooManyRequests(4, get_mailbox)
             self.test_successful_mailbox(mailbox=mock_server.get)
+
+    def test_origfrom_field(self):
+        mock_data = defaultdict(str)
+        mock_data['origfrom'] = 'Mock Name <mock@domain.com>'
+        mock_message = wrapper.Message(None, mock_data)
+
+        # Backwards compatible message objects.
+        self.assertEqual(mock_message.fromshort, 'Mock Name')
+        self.assertEqual(mock_message.fromfull, 'mock@domain.com')
 
 
 if __name__ == '__main__':

--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -1,5 +1,6 @@
 import json
 from time import sleep
+from email.utils import parseaddr, formataddr
 
 try:
     from urllib.request import urlopen
@@ -44,9 +45,18 @@ class Message(object):
         self.time = data['time']
         self.to = data['to']
         self.seconds_ago = data['seconds_ago']
-        self.fromfull = data['fromfull']
-        self.fromshort = data['from']
         self.ip = data['ip']
+
+        try:
+            self.origfrom = data['origfrom']
+            # Support old Message attributes
+            self.fromshort, self.fromfull = parseaddr(self.origfrom)
+        except KeyError:
+            # Try the old data model
+            self.fromfull = data['fromfull']
+            self.fromshort = data['from']
+            self.origfrom = formataddr((self.fromshort, self.fromfull))
+
         self.headers = {}
         self.body = ""
 


### PR DESCRIPTION
Backwards compatibility with `fromfull` and `fromshort` is kept for where it might be needed.

As far as I can tell, this change is necessary for the python Mailinator client to be usable at the moment.