### PR TITLE
Make `ip` optional in `Message` objects

### DIFF
--- a/pymailinator/wrapper.py
+++ b/pymailinator/wrapper.py
@@ -45,7 +45,7 @@ class Message(object):
         self.time = data['time']
         self.to = data['to']
         self.seconds_ago = data['seconds_ago']
-        self.ip = data['ip']
+        self.ip = data.get('ip')
 
         try:
             self.origfrom = data['origfrom']


### PR DESCRIPTION
The `ip` field stopped appearing in message responses recently which resulted in unhandled exceptions when using pymailinator.